### PR TITLE
chore: upgrade Node.js 22 → 24 (LTS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY src ./src
 RUN cargo build --release --bin dbv
 
 # ── Stage 4: build the React frontend ────────────────────────────────────────
-FROM node:22-slim AS frontend-builder
+FROM node:24-slim AS frontend-builder
 WORKDIR /app/frontend
 COPY frontend/package*.json ./
 RUN npm ci

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
## Summary
Upgrades Node.js from 22 to 24 (current LTS since October 2025) to stay ahead of deprecation warnings.

## Changes
- `.github/workflows/ci.yml`: `node-version: 22` → `node-version: 24`
- `Dockerfile`: `node:22-slim` → `node:24-slim` (build stage)
- `frontend/package.json`: added `engines.node >= 24`

## Testing
- [x] Frontend build passes locally
- [x] No breaking changes in dependencies (TypeScript 6, Vite 8, React 19, @types/node 25 all support Node 24)