### PR TITLE
chore: bump docker/login-action and setup-buildx-action to v4

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,10 +29,10 @@ jobs:
         uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}


### PR DESCRIPTION
## Changes
- `docker/login-action`: v3 → v4 (latest)
- `docker/setup-buildx-action`: v3 → v4 (latest)

Other Docker actions (`setup-qemu-action@v4`, `build-push-action@v7`, `metadata-action@v6`) are already on their latest major versions.