### PR TITLE
chore: bump actions/cache v4 → v5 in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache Cargo registry + build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry/index


### PR DESCRIPTION
## Changes
- `actions/cache`: v4 → v5.0.4 (latest)

Other actions in ci.yml (`actions/checkout@v6`, `actions/setup-node@v6`) are already on their latest major versions.