### PR TITLE
chore: update LICENSE copyright to full name Dannys Janssen

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Dannys
+Copyright (c) 2026 Dannys Janssen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Replaces `Dannys` with `Dannys Janssen` in the MIT license copyright line.