### PR TITLE
fix: override dompurify >=3.3.3 to resolve 4 Dependabot CVEs

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,9 @@
         "typescript": "^6.0.2",
         "typescript-eslint": "^8.57.0",
         "vite": "^8.0.1"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1622,9 +1625,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
       "optionalDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,9 @@
   "engines": {
     "node": ">=24"
   },
+  "overrides": {
+    "dompurify": ">=3.3.3"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
## Problem
`dompurify@3.2.7` is pulled in transitively via `@monaco-editor/react → monaco-editor → dompurify` and has 4 known vulnerabilities flagged by Dependabot.

## Fix
Added an npm `overrides` entry to force all dependents to resolve `dompurify` to `>=3.3.3`:

```json
"overrides": {
  "dompurify": ">=3.3.3"
}
```

## Verification
- `npm install` reports **0 vulnerabilities**
- `npm list dompurify` confirms **3.3.3 (overridden)**
- Frontend build passes cleanly