### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/dannys-janssen/dbv/security/code-scanning/1](https://github.com/dannys-janssen/dbv/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions:` block that grants only the minimal required scopes to the `GITHUB_TOKEN`. For a pure CI workflow that only checks out code, caches dependencies, and runs tests/builds, `contents: read` at the workflow level is typically sufficient and safest.

The best fix here is to add a top-level `permissions:` block (alongside `on:` and `concurrency:`) so it applies to all jobs (`rust` and `frontend`). Neither job needs to write to the repository or interact with issues/PRs, so `contents: read` is enough. No changes to steps, actions, or behavior are required: `actions/checkout`, `actions/cache`, `dtolnay/rust-toolchain`, and `actions/setup-node` work with a read-only `contents` permission.

Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `concurrency:` block (e.g., after line 7). No imports or additional methods are needed since this is just YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
