### PR TITLE
fix: suppress CodeQL SSRF false positives in auth_proxy.rs

### DIFF
--- a/src/routes/auth_proxy.rs
+++ b/src/routes/auth_proxy.rs
@@ -27,7 +27,7 @@ pub async fn login(
     );
 
     let resp = reqwest::Client::new()
-        .post(&token_url)
+        .post(&token_url) // lgtm[rust/ssrf] - token_url is constructed solely from operator-controlled env vars (KEYCLOAK_URL, KEYCLOAK_REALM); no user input is interpolated into the URL
         .form(&[
             ("client_id", state.config.keycloak_client_id.as_str()),
             ("username", body.username.as_str()),
@@ -66,7 +66,7 @@ pub async fn refresh(
     );
 
     let resp = reqwest::Client::new()
-        .post(&token_url)
+        .post(&token_url) // lgtm[rust/ssrf] - token_url is constructed solely from operator-controlled env vars (KEYCLOAK_URL, KEYCLOAK_REALM); no user input is interpolated into the URL
         .form(&[
             ("client_id", state.config.keycloak_client_id.as_str()),
             ("refresh_token", body.refresh_token.as_str()),


### PR DESCRIPTION
## Summary

Suppresses two CodeQL `rust/ssrf` false-positive alerts flagged at [code-scanning alert #3](https://github.com/dannys-janssen/dbv/security/code-scanning/3).

## Why this is a false positive


```rust
    "{}/realms/{}/protocol/openid-connect/token",
    state.config.keycloak_url,   // from env var KEYCLOAK_URL  (operator-controlled)
    state.config.keycloak_realm  // from env var KEYCLOAK_REALM (operator-controlled)
);
```

Both interpolated values come exclusively from environment variables parsed at startup by `envy` in `config.rs`. User-supplied values (`username`, `password`, `refresh_token`) are only passed as **form fields in the POST body** and are never part of the destination URL. There is no code path through which a request caller can influence the target host.

## Change

Added `// lgtm[rust/ssrf]` suppression comments on both `.post(&token_url)` call sites:

| Location | Handler |
|---|---|
| Line 30 | `login` — password grant |
| Line 69 | `refresh` — refresh-token grant |

No runtime behaviour is changed.