### PR TITLE
Optimize Docker image publishing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+target
+frontend/node_modules
+frontend/dist
+kubernetes
+.env
+.env.*
+!.env.example
+docker-compose.yml
+README.md
+LICENSE

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -355,10 +355,11 @@ The UI targets WCAG 2.1 Level AA. Key patterns:
   - `cargo test --all-features`
   - Frontend: `npm ci && npm run build`
   - Uses `dtolnay/rust-toolchain@stable` and `actions/cache` for Cargo + npm caching.
-- **`.github/workflows/docker.yml`** — runs on push to `main` and on `v*.*.*` tags:
+- **`.github/workflows/docker.yml`** — runs on `v*.*.*` tags and manual dispatch:
   - Multi-arch build: `linux/amd64` + `linux/arm64` via QEMU + Buildx.
   - Pushes to `ghcr.io/<owner>/dbv`.
-  - Tags: `:latest` (main), `:1.2.3` / `:1.2` / `:1` (semver tags), `:sha-<short>`.
+  - Tags: `:latest`, `:1.2.3` / `:1.2` / `:1` (semver tags), `:sha-<short>`.
+  - Adds OCI labels for authors, vendor, title, documentation, source, description, and license metadata.
   - Uses `GITHUB_TOKEN` — no extra secrets required.
   - Uses GitHub Actions cache (`type=gha`) for Docker layer caching.
 - **`.github/dependabot.yml`** — weekly PRs for Cargo, npm, and GitHub Actions dependencies.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,6 @@ name: Docker
 
 on:
   push:
-    branches: [main]
     tags: ["v*.*.*"]
   workflow_dispatch:
 
@@ -44,14 +43,22 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            # Branch push → :latest
-            type=raw,value=latest,enable={{is_default_branch}}
+            # Version tags and manual runs update :latest
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v') }}
             # Semver tag → :1.2.3 + :1.2 + :1
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             # Short SHA for traceability
             type=sha,prefix=sha-
+          labels: |
+            org.opencontainers.image.authors=Danny Janssen
+            org.opencontainers.image.vendor=dannys-janssen
+            org.opencontainers.image.title=dbv
+            org.opencontainers.image.documentation=https://github.com/dannys-janssen/dbv#readme
+            org.opencontainers.image.source=https://github.com/dannys-janssen/dbv
+            org.opencontainers.image.description=Browser-based MongoDB viewer and editor secured with Keycloak OAuth2/JWT authentication.
+            org.opencontainers.image.licenses=MIT
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -61,5 +68,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 # ── Stage 1: compute recipe for dependency caching ──────────────────────────
 FROM rust:1-slim-bookworm AS chef
 RUN cargo install cargo-chef --locked
@@ -11,32 +13,42 @@ RUN cargo chef prepare --recipe-path recipe.json
 # ── Stage 2: build dependencies (cached layer) ───────────────────────────────
 FROM chef AS builder-deps
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo chef cook --release --locked --recipe-path recipe.json
 
 # ── Stage 3: build the application ───────────────────────────────────────────
 FROM builder-deps AS builder
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src
-RUN cargo build --release --bin dbv
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo build --release --locked --bin dbv && \
+    strip target/release/dbv
 
 # ── Stage 4: build the React frontend ────────────────────────────────────────
 FROM node:24-alpine AS frontend-builder
 WORKDIR /app/frontend
 COPY frontend/package*.json ./
-RUN npm ci
+RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --no-fund
 COPY frontend ./
 RUN npm run build
 
 # ── Stage 5: minimal runtime image ───────────────────────────────────────────
-FROM debian:bookworm-slim AS runtime
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
 WORKDIR /app
 COPY --from=builder /app/target/release/dbv ./dbv
 COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
+
+LABEL org.opencontainers.image.authors="Danny Janssen" \
+      org.opencontainers.image.vendor="dannys-janssen" \
+      org.opencontainers.image.title="dbv" \
+      org.opencontainers.image.documentation="https://github.com/dannys-janssen/dbv#readme" \
+      org.opencontainers.image.source="https://github.com/dannys-janssen/dbv" \
+      org.opencontainers.image.description="Browser-based MongoDB viewer and editor secured with Keycloak OAuth2/JWT authentication." \
+      org.opencontainers.image.licenses="MIT"
 
 ENV FRONTEND_DIST=/app/frontend/dist
 ENV SERVER_HOST=0.0.0.0
 ENV SERVER_PORT=8080
 
 EXPOSE 8080
-CMD ["./dbv"]
+CMD ["/app/dbv"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ WORKDIR /app
 COPY --from=builder /app/target/release/dbv ./dbv
 COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
 
-LABEL org.opencontainers.image.authors="Danny Janssen" \
+LABEL org.opencontainers.image.authors="Dannys Janssen" \
       org.opencontainers.image.vendor="dannys-janssen" \
       org.opencontainers.image.title="dbv" \
       org.opencontainers.image.documentation="https://github.com/dannys-janssen/dbv#readme" \

--- a/README.md
+++ b/README.md
@@ -741,13 +741,13 @@ Replace the two badge URLs at the top of this file with your actual GitHub usern
 | Workflow | File | Trigger | What it does |
 |---|---|---|---|
 | **CI** | `.github/workflows/ci.yml` | Push / PR → `main` | `cargo fmt`, `cargo clippy`, `cargo test`, `npm ci && npm run build` |
-| **Docker** | `.github/workflows/docker.yml` | Push → `main`, tags `v*.*.*`, manual | Builds multi-arch image (`linux/amd64` + `linux/arm64`) and pushes to `ghcr.io` |
+| **Docker** | `.github/workflows/docker.yml` | Tags `v*.*.*`, manual | Builds multi-arch image (`linux/amd64` + `linux/arm64`) and pushes to `ghcr.io` |
 
 The Docker workflow uses the built-in `GITHUB_TOKEN` — **no extra secrets are needed** for `ghcr.io` publishing.
 
 #### Published Docker image
 
-After the first push to `main` the image is available at:
+After the first tagged release or manual publish, the image is available at:
 
 ```
 ghcr.io/dannys-janssen/dbv:latest
@@ -769,6 +769,8 @@ git push origin v1.0.0
 ```
 
 This triggers the Docker workflow which publishes `ghcr.io/…/dbv:1.0.0`, `:1.0`, `:1`, and `:latest`.
+
+The published image includes standard OCI metadata labels for authors, vendor, title, documentation, source, description, and license information so registries can classify it correctly.
 
 #### Dependabot
 


### PR DESCRIPTION
## Summary
- publish the Docker image only for version tags and manual workflow runs
- add OCI image metadata labels and reduce the Docker build context
- move the runtime image to distroless and keep the Rust/Node build stages cache-friendly

Closes #29