### PR TITLE
Fix Docker release lockfile mismatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "dbv"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
## Summary
- sync the root package entry in Cargo.lock with the 0.2.3 version bump
- restore Docker builds that run cargo with --locked

## Root cause
The 0.2.3 release bump updated Cargo.toml but left the root dbv package entry in Cargo.lock at 0.2.2, so the Docker workflow failed during cargo build --locked.

Fixes the Docker workflow failure from run 24858359561.