### PR TITLE
Merge missing v0.2.7 release commit into main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,7 +498,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "dbv"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbv"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2024"
 license = "MIT"
 

--- a/kubernetes/helm/dbv/Chart.yaml
+++ b/kubernetes/helm/dbv/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: dbv
 description: Browser-based MongoDB viewer and editor secured with Keycloak OAuth2/JWT
 type: application
-version: 0.2.6
-appVersion: "0.2.6"
+version: 0.2.7
+appVersion: "0.2.7"
 keywords:
   - mongodb
   - database

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -13,7 +13,7 @@ info:
     **Roles:**
     - `dbv-viewer` — read-only (GET endpoints, export, aggregate, schema, stats)
     - `dbv-admin` — read + write (all endpoints)
-  version: "0.2.6"
+  version: "0.2.7"
   license:
     name: MIT
 


### PR DESCRIPTION
## Summary
- merge the original release branch so commit d9010fe becomes reachable from main
- bring the v0.2.7 version bumps for Cargo, Helm chart, and OpenAPI back onto main

## Why
The v0.2.7 tag points to d9010fe, but that commit was not reachable from main after PR #99 merged before the release commit was added.

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features
- cd frontend && npm run build
- helm lint ./kubernetes/helm/dbv --set config.mongodbUri=x --set config.keycloakUrl=x --set config.keycloakRealm=x --set config.keycloakClientId=x