### PR TITLE
Add GitHub security policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+> Suspected security vulnerability? Please do **not** use this template. Follow the instructions in [`SECURITY.md`](../../SECURITY.md) and report it privately.
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability report
+    url: https://github.com/dannys-janssen/dbv/security/policy
+    about: Review the security policy and report vulnerabilities privately instead of opening a public issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+| --- | --- |
+| `main` | Yes |
+| Latest release | Yes |
+| Older releases | No |
+
+## Reporting a vulnerability
+
+Please do **not** open public GitHub issues for suspected security vulnerabilities.
+
+Use GitHub's private vulnerability reporting flow for this repository:
+
+1. Open the repository's **Security** tab.
+2. Click **Report a vulnerability**.
+3. Include the affected area, impact, reproduction steps, version or commit, and any relevant configuration details.
+
+If private vulnerability reporting is not available, contact the maintainer privately through GitHub instead of posting details publicly.
+
+Please avoid sending secrets, production credentials, or personal data in your report unless they are strictly required to reproduce the issue.
+
+## What to expect
+
+- Reports will be acknowledged as soon as reasonably possible.
+- Valid reports will be investigated and triaged privately.
+- Fixes will be released as soon as a safe remediation is ready.
+- Public disclosure should wait until a fix or mitigation is available and coordinated.
+
+## Scope
+
+This policy covers the code and deployment assets in this repository, including:
+
+- the Rust backend and React frontend
+- Docker and Compose configuration
+- Helm chart and Kubernetes manifests
+- published container images built from this repository


### PR DESCRIPTION
## Summary
- add a repository SECURITY.md with supported versions and private vulnerability reporting guidance
- add a GitHub issue contact link pointing reporters to the security policy
- warn in the bug report template not to disclose vulnerabilities publicly

## Testing
- documentation/template changes only
