### PR TITLE
Add code of conduct

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: true
 contact_links:
+  - name: Code of conduct
+    url: https://github.com/dannys-janssen/dbv/blob/main/CODE_OF_CONDUCT.md
+    about: Review the community expectations and reporting guidance for this repository.
   - name: Security vulnerability report
     url: https://github.com/dannys-janssen/dbv/security/policy
     about: Review the security policy and report vulnerabilities privately instead of opening a public issue.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,60 @@
+# Code of Conduct
+
+## Our commitment
+
+We want `dbv` to be a welcoming, respectful, and constructive project for everyone who participates.
+
+Contributors, maintainers, and community members are expected to interact in ways that support collaboration, learning, and mutual respect.
+
+## Expected behaviour
+
+Examples of behaviour that help create a positive environment include:
+
+- being respectful in discussions, reviews, and issue reports
+- assuming good intent and giving feedback constructively
+- focusing on what is best for the project and its users
+- being open to different viewpoints, experience levels, and backgrounds
+- taking responsibility for mistakes and correcting them promptly
+
+## Unacceptable behaviour
+
+Examples of unacceptable behaviour include:
+
+- harassment, intimidation, threats, or discriminatory language
+- personal attacks, insults, trolling, or deliberately inflammatory comments
+- sexual language or unwanted sexual attention
+- publishing someone else's private information without permission
+- sustained disruption of discussions, reviews, or project workflows
+- any other conduct that a maintainer reasonably determines is inappropriate for this community
+
+## Scope
+
+This code of conduct applies to repository spaces and project-related interactions, including:
+
+- GitHub issues, pull requests, reviews, and discussions
+- project documentation and community conversations related to this repository
+- other public or private interactions when someone is representing this project
+
+## Reporting concerns
+
+If you experience or witness behaviour that violates this code of conduct, report it privately to the repository maintainers through GitHub rather than raising it in a public issue or pull request.
+
+When possible, include:
+
+- what happened
+- where it happened
+- who was involved
+- links, screenshots, or other relevant context
+
+Reports will be reviewed as promptly and discreetly as possible.
+
+## Enforcement
+
+Maintainers may take any action they consider appropriate to protect the project and its participants, including:
+
+- warning a contributor
+- removing or editing content
+- temporarily or permanently restricting participation
+- closing or locking discussions
+
+Maintainers will aim to enforce this policy fairly and consistently.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A browser-based MongoDB viewer and editor secured with Keycloak OAuth2/JWT authe
   - [Using the App](#using-the-app)
   - [Roles and Permissions](#roles-and-permissions)
 - [Developer Guide](#developer-guide)
+  - [Code of Conduct](#code-of-conduct)
   - [Contributing](#contributing)
   - [Architecture](#architecture)
   - [Prerequisites](#prerequisites)
@@ -378,6 +379,10 @@ The **Commands** tab provides a split-panel MongoDB command runner:
 ---
 
 ## Developer Guide
+
+### Code of Conduct
+
+See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community expectations and reporting guidance.
 
 ### Contributing
 


### PR DESCRIPTION
## Summary
- add a repository CODE_OF_CONDUCT.md with community expectations, reporting, and enforcement guidance
- link the code of conduct from the README developer guide
- add a GitHub issue contact link to help contributors find the policy

## Testing
- documentation changes only
