### PR TITLE
Release v0.2.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,7 +498,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "dbv"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbv"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2024"
 license = "MIT"
 

--- a/kubernetes/helm/dbv/Chart.yaml
+++ b/kubernetes/helm/dbv/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: dbv
 description: Browser-based MongoDB viewer and editor secured with Keycloak OAuth2/JWT
 type: application
-version: 0.2.8
-appVersion: "0.2.8"
+version: 0.2.9
+appVersion: "0.2.9"
 keywords:
   - mongodb
   - database

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -13,7 +13,7 @@ info:
     **Roles:**
     - `dbv-viewer` — read-only (GET endpoints, export, aggregate, schema, stats)
     - `dbv-admin` — read + write (all endpoints)
-  version: "0.2.8"
+  version: "0.2.9"
   license:
     name: MIT
 


### PR DESCRIPTION
## Summary
- bump the Rust package version to 0.2.9
- update the Helm chart version and appVersion to 0.2.9
- update the embedded OpenAPI spec version to 0.2.9

## Validation
- cargo fmt --all --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features
- cd frontend && npm test -- --watch=false
- cd frontend && npm run build
- helm lint ./kubernetes/helm/dbv --set config.mongodbUri=x --set config.keycloakUrl=x --set config.keycloakRealm=x --set config.keycloakClientId=x