### PR TITLE
Release v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,7 +498,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "dbv"
-version = "0.2.9"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbv"
-version = "0.2.9"
+version = "0.3.0"
 edition = "2024"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -832,7 +832,7 @@ dbv:
 #### Releasing a new version
 
 ```bash
-git tag v1.0.0
+git tag v0.3.0
 git push origin v1.0.0
 ```
 

--- a/kubernetes/helm/dbv/Chart.yaml
+++ b/kubernetes/helm/dbv/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: dbv
 description: Browser-based MongoDB viewer and editor secured with Keycloak OAuth2/JWT
 type: application
-version: 0.2.9
-appVersion: "0.2.9"
+version: 0.3.0
+appVersion: "0.3.0"
 keywords:
   - mongodb
   - database

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -13,7 +13,7 @@ info:
     **Roles:**
     - `dbv-viewer` — read-only (GET endpoints, export, aggregate, schema, stats)
     - `dbv-admin` — read + write (all endpoints)
-  version: "0.2.9"
+  version: "0.3.0"
   license:
     name: MIT
 


### PR DESCRIPTION
## Summary

- Bump Rust package version to `0.3.0`
- Update Helm chart version and appVersion to `0.3.0`
- Update embedded OpenAPI spec version to `0.3.0`
- Update README release section

## Wiki

Release notes published to the [project wiki](https://github.com/dannys-janssen/dbv/wiki/Release-v0.3.0).

## Validation

- `cargo fmt --all --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test --all-features` ✅ (60 tests passed)
- `cd frontend && npm test -- --watch=false` ✅ (139 tests passed)
- `cd frontend && npm run build` ✅
- `helm lint ./kubernetes/helm/dbv ...` ✅

## After Merge

Once this PR is merged into `main`, invoke the release skill to tag:

```
Use the /release skill to tag v0.3.0
```