### PR TITLE
fix: create GitHub Release as part of release skill tag step

### DIFF
--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -333,6 +333,26 @@ git ls-remote --tags origin "refs/tags/${TAG}"
 
 If the output is empty the push failed — retry or ask the user to push manually.
 
+### 10e. Create the GitHub Release
+
+A git tag alone does **not** create a GitHub Release (the release notes visible on the
+releases page). Create one explicitly using `gh release create` with `--generate-notes`
+so GitHub auto-populates "What's Changed" from merged PRs since the previous tag:
+
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+gh release create "${TAG}" \
+  --repo "${REPO}" \
+  --title "${TAG}" \
+  --generate-notes \
+  --latest
+echo "GitHub Release created: https://github.com/${REPO}/releases/tag/${TAG}"
+```
+
+Verify by opening the URL printed above and confirming the "What's Changed" section
+is populated. If `--generate-notes` produces no content (e.g. no PRs since last tag),
+add `--notes "See [wiki release notes](https://github.com/${REPO}/wiki/Release-${TAG})"` instead.
+
 ## 11. Report back
 
 Print a full summary:
@@ -344,6 +364,7 @@ Print a full summary:
 ✅ Wiki page created: Release-v<VERSION>
 ✅ PR opened: <PR_URL>
 ✅ Tag v<VERSION> pushed → Docker build triggered
+✅ GitHub Release created: https://github.com/<OWNER>/dbv/releases/tag/v<VERSION>
 
 Docker images will be published at:
   ghcr.io/<OWNER>/dbv:v<VERSION>

--- a/README.md
+++ b/README.md
@@ -831,12 +831,35 @@ dbv:
 
 #### Releasing a new version
 
-```bash
-git tag v1.0.0
-git push origin v1.0.0
+The project ships a Copilot CLI skill at `.github/skills/release/` that automates the full release workflow. To use it, start a Copilot CLI session in the repo root and run:
+
+```
+Use the /release skill to release v0.3.0
 ```
 
-This triggers the Docker workflow which publishes `ghcr.io/…/dbv:1.0.0`, `:1.0`, `:1`, and `:latest`.
+The skill will:
+
+1. Create a `release/vX.Y.Z` branch off `main`
+2. Bump the version in `Cargo.toml`, `Cargo.lock`, `kubernetes/helm/dbv/Chart.yaml`, and `src/openapi.yaml`
+3. Update this README's release section
+4. Run the full CI validation suite (fmt, clippy, tests, frontend build, helm lint)
+5. Publish a release-notes page to the [project wiki](https://github.com/dannys-janssen/dbv/wiki)
+6. Open a pull request against `main`
+
+After the PR is merged, tell Copilot CLI to tag the release:
+
+```
+Use the /release skill to tag v0.3.0
+```
+
+The skill verifies the PR is merged and the version on `main` matches, then creates an annotated tag and pushes it:
+
+```bash
+git tag -a v0.3.0 -m "Release v0.3.0"
+git push origin v0.3.0
+```
+
+This triggers the Docker workflow which publishes `ghcr.io/dannys-janssen/dbv:v0.3.0`, `:0.3.0`, `:0.3`, `:0`, and `:latest`.
 
 The published image includes standard OCI metadata labels for authors, vendor, title, documentation, source, description, and license information so registries can classify it correctly.
 


### PR DESCRIPTION
PR #175 was merged before this fix was added.

## What's Changed

Adds step 10e to the release skill: after pushing the git tag, run `gh release create --generate-notes --latest` to create a proper GitHub Release with auto-generated 'What's Changed' notes.

**Root cause:** a git tag and a GitHub Release are distinct objects. Without this step the releases page shows no notes for the new tag, even though the wiki page exists.

## Fix

```bash
gh release create "${TAG}" --repo "${REPO}" --title "${TAG}" --generate-notes --latest
```