### PR TITLE
Release v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,7 +537,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "dbv"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbv"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -834,7 +834,7 @@ dbv:
 The project ships a Copilot CLI skill at `.github/skills/release/` that automates the full release workflow. To use it, start a Copilot CLI session in the repo root and run:
 
 ```
-Use the /release skill to release v0.3.0
+Use the /release skill to release v0.3.1
 ```
 
 The skill will:
@@ -849,17 +849,17 @@ The skill will:
 After the PR is merged, tell Copilot CLI to tag the release:
 
 ```
-Use the /release skill to tag v0.3.0
+Use the /release skill to tag v0.3.1
 ```
 
 The skill verifies the PR is merged and the version on `main` matches, then creates an annotated tag and pushes it:
 
 ```bash
-git tag -a v0.3.0 -m "Release v0.3.0"
-git push origin v0.3.0
+git tag -a v0.3.1 -m "Release v0.3.1"
+git push origin v0.3.1
 ```
 
-This triggers the Docker workflow which publishes `ghcr.io/dannys-janssen/dbv:v0.3.0`, `:0.3.0`, `:0.3`, `:0`, and `:latest`.
+This triggers the Docker workflow which publishes `ghcr.io/dannys-janssen/dbv:v0.3.1`, `:0.3.1`, `:0.3`, `:0`, and `:latest`.
 
 The published image includes standard OCI metadata labels for authors, vendor, title, documentation, source, description, and license information so registries can classify it correctly.
 

--- a/kubernetes/helm/dbv/Chart.yaml
+++ b/kubernetes/helm/dbv/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: dbv
 description: Browser-based MongoDB viewer and editor secured with Keycloak OAuth2/JWT
 type: application
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.3.1
+appVersion: "0.3.1"
 keywords:
   - mongodb
   - database

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -13,7 +13,7 @@ info:
     **Roles:**
     - `dbv-viewer` — read-only (GET endpoints, export, aggregate, schema, stats)
     - `dbv-admin` — read + write (all endpoints)
-  version: "0.3.0"
+  version: "0.3.1"
   license:
     name: MIT
 


### PR DESCRIPTION
## Summary

- Bump Rust package version to `0.3.1`
- Update Helm chart version and appVersion to `0.3.1`
- Update embedded OpenAPI spec version to `0.3.1`
- Update README release section

## Wiki

Release notes published to the [project wiki](https://github.com/dannys-janssen/dbv/wiki/Release-v0.3.1).

## Validation

- `cargo fmt --all --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test --all-features` ✅ (60 tests)
- `cd frontend && npm test -- --watch=false` ✅ (142 tests)
- `cd frontend && npm run build` ✅
- `helm lint ./kubernetes/helm/dbv ...` ✅

## After Merge

Once this PR is merged into `main`, invoke the release skill again with `tag v0.3.1` to create and push the release tag, which triggers Docker image publishing.